### PR TITLE
Fixing "forkme" link

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
     </head>
     <body>
 
-        <a href="https://github.com/dfcb/BigVideo.js">
+        <a href="https://github.com/dfcb/controldeck.js/">
             <img style="position: fixed; top: 0; right: 0; border: 0; z-index: 11;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" alt="Fork me on GitHub" />
         </a>
 


### PR DESCRIPTION
Previously it was pointing to your BigVideo.js project
