### PR TITLE
Add generic framework support

### DIFF
--- a/public/controldeck-slides.js
+++ b/public/controldeck-slides.js
@@ -7,6 +7,7 @@ else if (typeof Reveal !== 'undefined')             messageHandler = updateRevea
 else if (typeof impress !== 'undefined')            messageHandler = updateImpress;
 else if (typeof jQuery.jmpress !== 'undefined')     messageHandler = updateJmpress;
 else if (typeof jQuery.scrolldeck !== 'undefined')  messageHandler = updateScrollDeck;
+else    messageHandler = updateGeneric;
 
 // separated in case we want to differentiate in the future
 function updateDeckJS(message) {
@@ -41,6 +42,12 @@ function updateJmpress(message) {
 }
 function updateScrollDeck(message) {
     console.log('updateScrollDeck '+message);
+    var e = jQuery.Event('keydown');
+    e.which = e.keyCode = parseInt(message,10);
+    $(document).trigger(e);
+}
+function updateGeneric(message) {
+    console.log('updateGeneric '+message);
     var e = jQuery.Event('keydown');
     e.which = e.keyCode = parseInt(message,10);
     $(document).trigger(e);


### PR DESCRIPTION
Hey again, John :)

I've added a generic handler which is used if the framework isn't officially supported, but this should do the trick for most (if not all) current and future frameworks.

I wrote [Fathom.js](http://markdalgleish.com/projects/fathom/) a while ago, and I've begun dabbling with a new one called [Bespoke.js](https://github.com/markdalgleish/bespoke.js), and this update would make it work with either of these without any further modification, so I think it's a pretty big win.

Thanks :)
